### PR TITLE
Include Digitalax in the Royalty Registry

### DIFF
--- a/contracts/RoyaltyRegistry.sol
+++ b/contracts/RoyaltyRegistry.sol
@@ -14,6 +14,7 @@ import "@manifoldxyz/libraries-solidity/contracts/access/IAdminControl.sol";
 import "./IRoyaltyRegistry.sol";
 import "./specs/INiftyGateway.sol";
 import "./specs/IFoundation.sol";
+import "./specs/IDigitalax.sol";
 
 /**
  * @dev Registry to lookup royalty configurations
@@ -71,6 +72,12 @@ contract RoyaltyRegistry is ERC165, OwnableUpgradeable, IRoyaltyRegistry {
 
         try IAccessControlUpgradeable(tokenAddress).hasRole(0x00, _msgSender()) returns (bool hasRole) {
             if (hasRole) return true;
+        } catch {}
+
+        try IDigitalax(tokenAddress).accessControls() returns (address externalAccessControls){
+            try IDigitalaxAccessControls(externalAccessControls).hasAdminRole(_msgSender()) returns (bool hasRole) {
+                if (hasRole) return true;
+            } catch {}
         } catch {}
 
         // Nifty Gateway overrides

--- a/contracts/mocks/Mock.sol
+++ b/contracts/mocks/Mock.sol
@@ -13,6 +13,7 @@ import "../specs/IRarible.sol";
 import "../specs/IFoundation.sol";
 import "../specs/IEIP2981.sol";
 import "../specs/INiftyGateway.sol";
+import "../specs/IDigitalax.sol";
 import "../IRoyaltyEngineV1.sol";
 
 /**
@@ -164,6 +165,29 @@ contract MockNiftyRegistry is INiftyRegistry {
 
     function isValidNiftySender(address sending_key) external view override returns (bool) {
         return sending_key == _approvedAddress;
+    }
+}
+
+contract MockDigitalaxNFT is IDigitalax {
+    address private externalAccessControls;
+    function accessControls() external view override returns (address){
+        return externalAccessControls;
+    }
+
+    constructor(address _accessControls) {
+        externalAccessControls = _accessControls;
+    }
+}
+
+contract MockDigitalaxAccessControls is IDigitalaxAccessControls {
+    address private _approvedAddress;
+
+    constructor(address approvedAddress) {
+        _approvedAddress = approvedAddress;
+    }
+
+    function hasAdminRole(address _account) external view override returns (bool){
+        return _account == _approvedAddress;
     }
 }
 

--- a/contracts/specs/IDigitalax.sol
+++ b/contracts/specs/IDigitalax.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Digitalax nfts
+ */
+interface IDigitalax {
+   function accessControls() external view returns (address);
+}
+
+/**
+ * @dev Digitalax Access Controls Simple
+ */
+interface IDigitalaxAccessControls {
+   function hasAdminRole(address _account) external view returns (bool);
+}

--- a/test/registry.js
+++ b/test/registry.js
@@ -13,6 +13,8 @@ const MockEIP2981 = artifacts.require("MockEIP2981");
 const MockRoyaltyPayer = artifacts.require("MockRoyaltyPayer");
 const MockNiftyBuilder = artifacts.require("MockNiftyBuilder");
 const MockNiftyRegistry = artifacts.require("MockNiftyRegistry");
+const MockDigitalaxNFT = artifacts.require("MockDigitalaxNFT");
+const MockDigitalaxAccessControls = artifacts.require("MockDigitalaxAccessControls");
 const MockERC1155PresetMinterPauser = artifacts.require("MockERC1155PresetMinterPauser");
 
 contract('Registry', function ([...accounts]) {
@@ -42,6 +44,8 @@ contract('Registry', function ([...accounts]) {
     var mockEIP2981;
     var mockRoyaltyPayer;
     var mockNiftyRegistry;
+    var mockDigitalaxNFT;
+    var mockDigitalaxAccessControls;
     var mockNiftyBuilder;
     var mockERC1155PresetMinterPauser;
 
@@ -59,6 +63,8 @@ contract('Registry', function ([...accounts]) {
       mockRoyaltyPayer = await MockRoyaltyPayer.new();
       mockNiftyRegistry = await MockNiftyRegistry.new(niftyDeployer);
       mockNiftyBuilder = await MockNiftyBuilder.new(mockNiftyRegistry.address);
+      mockDigitalaxAccessControls = await MockDigitalaxAccessControls.new(owner, {from: owner});
+      mockDigitalaxNFT = await MockDigitalaxNFT.new(mockDigitalaxAccessControls.address, {from: owner});
       mockERC1155PresetMinterPauser = await MockERC1155PresetMinterPauser.new({from: erc1155PresetDeployer});
     });
 
@@ -80,6 +86,7 @@ contract('Registry', function ([...accounts]) {
       assert.equal(false, await registry.overrideAllowed(mockRaribleV2.address, {from:random}));
       assert.equal(false, await registry.overrideAllowed(mockEIP2981.address, {from:random}));
       assert.equal(false, await registry.overrideAllowed(mockNiftyBuilder.address, {from:random}));
+      assert.equal(false, await registry.overrideAllowed(mockDigitalaxNFT.address, {from:random}));
       assert.equal(false, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, {from:random}));
 
       assert.equal(true, await registry.overrideAllowed(mockManifold.address, {from:manifoldDeployer}));
@@ -88,6 +95,7 @@ contract('Registry', function ([...accounts]) {
       assert.equal(true, await registry.overrideAllowed(mockRaribleV2.address, {from:raribleV2Deployer}));
       assert.equal(true, await registry.overrideAllowed(mockEIP2981.address, {from:eip2981Deployer}));
       assert.equal(true, await registry.overrideAllowed(mockNiftyBuilder.address, {from:niftyDeployer}));
+      assert.equal(true, await registry.overrideAllowed(mockDigitalaxNFT.address, {from:owner}));
       assert.equal(true, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, {from:erc1155PresetDeployer}));
     })
 


### PR DESCRIPTION
Include Digitalax in the Royalty Registry, to allow for the external access controls contract to be used to verify the override permission