### PR TITLE
RoyaltyEngine support of new multi-contract override interface (Art Blocks)

### DIFF
--- a/contracts/RoyaltyEngineV1.sol
+++ b/contracts/RoyaltyEngineV1.sol
@@ -17,6 +17,7 @@ import "./specs/IFoundation.sol";
 import "./specs/ISuperRare.sol";
 import "./specs/IEIP2981.sol";
 import "./specs/IZoraOverride.sol";
+import "./specs/IArtBlocks.sol";
 import "./IRoyaltyEngineV1.sol";
 import "./IRoyaltyRegistry.sol";
 
@@ -38,6 +39,7 @@ contract RoyaltyEngineV1 is ERC165, OwnableUpgradeable, IRoyaltyEngineV1 {
     int16 constant private EIP2981 = 5;
     int16 constant private SUPERRARE = 6;
     int16 constant private ZORA = 7;
+    int16 constant private ARTBLOCKS = 8;
 
     mapping (address => int16) _specCache;
 
@@ -148,6 +150,11 @@ contract RoyaltyEngineV1 is ERC165, OwnableUpgradeable, IRoyaltyEngineV1 {
                 require(recipients_.length == bps.length);
                 return (recipients_, _computeAmounts(value, bps), ZORA, royaltyAddress, addToCache);
             } catch {}
+            try IArtBlocksOverride(royaltyAddress).getRoyalties(tokenAddress, tokenId) returns(address payable[] memory recipients_, uint256[] memory bps) {
+                // Support Art Blocks override
+                require(recipients_.length == bps.length);
+                return (recipients_, _computeAmounts(value, bps), ARTBLOCKS, royaltyAddress, addToCache);
+            } catch {}
 
             // No supported royalties configured
             return (recipients, amounts, NONE, royaltyAddress, addToCache);
@@ -211,6 +218,12 @@ contract RoyaltyEngineV1 is ERC165, OwnableUpgradeable, IRoyaltyEngineV1 {
                 // Zora spec
                 uint256[] memory bps;
                 (recipients, bps) = IZoraOverride(royaltyAddress).convertBidShares(tokenAddress, tokenId);
+                require(recipients.length == bps.length);
+                return (recipients, _computeAmounts(value, bps), spec, royaltyAddress, addToCache);
+            } else if (spec == ARTBLOCKS) {
+                // Art Blocks Override spec
+                uint256[] memory bps;
+                (recipients, bps) = IArtBlocksOverride(royaltyAddress).getRoyalties(tokenAddress, tokenId);
                 require(recipients.length == bps.length);
                 return (recipients, _computeAmounts(value, bps), spec, royaltyAddress, addToCache);
             }

--- a/contracts/mocks/Mock.sol
+++ b/contracts/mocks/Mock.sol
@@ -226,7 +226,7 @@ contract MockArtBlocks is IArtBlocks {
     }
 }
 
-contract MultiContractRoyaltyOverrideArtBlocks is IMultiContractRoyaltyOverride, ERC165 {
+contract MockMultiContractRoyaltyOverrideArtBlocks is IMultiContractRoyaltyOverride, ERC165 {
 
     /**
      * @dev See {IERC165-supportsInterface}.

--- a/contracts/mocks/Mock.sol
+++ b/contracts/mocks/Mock.sol
@@ -201,11 +201,16 @@ contract MockDigitalaxAccessControls is IDigitalaxAccessControls {
 * Art Blocks Mocks
 */
 contract MockArtBlocks is IArtBlocks {
-     address public override admin;
+    address public override admin;
+    uint256 public defaultRoyaltyFee = 5;
 
-     constructor() {
-         admin = msg.sender;
-     }
+    constructor() {
+        admin = msg.sender;
+    }
+
+    function setDefaultRoyaltyFee(uint256 _defaultRoyaltyFee) public {
+        defaultRoyaltyFee = _defaultRoyaltyFee;
+    }
 
     function getRoyaltyData(uint256 /*_tokenId*/)
         public
@@ -218,11 +223,11 @@ contract MockArtBlocks is IArtBlocks {
             uint256 royaltyFeeByID
         )
     {
-        // generic, static response for mock
+        // generic response for mock
         artistAddress = address(0);
         additionalPayee = admin;
         additionalPayeePercentage = 20;
-        royaltyFeeByID = 5;
+        royaltyFeeByID = defaultRoyaltyFee;
     }
 }
 

--- a/contracts/overrides/IMultiContractRoyaltyOverride.sol
+++ b/contracts/overrides/IMultiContractRoyaltyOverride.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: artblocks.io
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IMultiContractRoyaltyOverride is IERC165 {
+    function getRoyalties(address tokenAddress, uint256 tokenId)
+        external
+        view
+        returns (address payable[] memory recipients_, uint256[] memory bps);
+}

--- a/contracts/specs/IArtBlocks.sol
+++ b/contracts/specs/IArtBlocks.sol
@@ -8,4 +8,14 @@ pragma solidity ^0.8.0;
 interface IArtBlocks {
    // document getter function of public variable
    function admin() external view returns (address);
+
+   function getRoyaltyData(uint256 _tokenId)
+   external
+   view
+   returns (
+      address artistAddress,
+      address additionalPayee,
+      uint256 additionalPayeePercentage,
+      uint256 royaltyFeeByID
+   );
 }

--- a/contracts/specs/IArtBlocks.sol
+++ b/contracts/specs/IArtBlocks.sol
@@ -9,7 +9,3 @@ interface IArtBlocks {
    // document getter function of public variable
    function admin() external view returns (address);
 }
-
-interface IArtBlocksOverride {
-   function getRoyalties(address tokenAddress, uint256 tokenId) external view returns(address payable[] memory, uint256[] memory);
-}

--- a/contracts/specs/IArtBlocks.sol
+++ b/contracts/specs/IArtBlocks.sol
@@ -9,3 +9,7 @@ interface IArtBlocks {
    // document getter function of public variable
    function admin() external view returns (address);
 }
+
+interface IArtBlocksOverride {
+   function getRoyalties(address tokenAddress, uint256 tokenId) external view returns(address payable[] memory, uint256[] memory);
+}

--- a/test/override.js
+++ b/test/override.js
@@ -4,9 +4,11 @@ const { deployProxy } = require('@openzeppelin/truffle-upgrades');
 const EIP2981RoyaltyOverride = artifacts.require("EIP2981RoyaltyOverride");
 const EIP2981RoyaltyOverrideCloneable = artifacts.require("EIP2981RoyaltyOverrideCloneable");
 const EIP2981RoyaltyOverrideFactory = artifacts.require("EIP2981RoyaltyOverrideFactory");
+const MultiContractRoyaltyOverrideArtBlocks = artifacts.require("MultiContractRoyaltyOverrideArtBlocks");
 const RoyaltyRegistry = artifacts.require("RoyaltyRegistry");
 const RoyaltyEngineV1 = artifacts.require("RoyaltyEngineV1")
 const MockContract = artifacts.require("MockContract");
+const MockArtBlocks = artifacts.require("MockArtBlocks");
 
 contract('Registry', function ([...accounts]) {
   const [
@@ -27,6 +29,7 @@ contract('Registry', function ([...accounts]) {
     var override;
     var overrideCloneable;
     var overrideFactory;
+    var mockArtBlocks;
 
     beforeEach(async function () {
       registry = await deployProxy(RoyaltyRegistry, {initializer: "initialize", from:owner});
@@ -34,6 +37,8 @@ contract('Registry', function ([...accounts]) {
       override = await EIP2981RoyaltyOverride.new({from: admin});
       overrideCloneable = await EIP2981RoyaltyOverrideCloneable.new();
       overrideFactory = await EIP2981RoyaltyOverrideFactory.new(overrideCloneable.address);
+      multiContractOverrideArtBlocks = await MultiContractRoyaltyOverrideArtBlocks.new({from: admin});
+      mockArtBlocks = await MockArtBlocks.new({from: another1});
     });
 
     it('override test', async function () {
@@ -44,6 +49,7 @@ contract('Registry', function ([...accounts]) {
     it('test', async function () {
       // Check override interface
       assert.equal(await override.supportsInterface("0xc69dbd8f"), true);
+      assert.equal(await override.supportsInterface("0xffffffff"), false);
 
       await truffleAssert.reverts(override.setTokenRoyalties([[1, another1, 10000]], {from:admin}), "Invalid bps");
       await truffleAssert.reverts(override.setDefaultRoyalty([another1, 10000], {from:admin}), "Invalid bps");
@@ -125,6 +131,46 @@ contract('Registry', function ([...accounts]) {
       assert.equal(result[1].length, 1);
       assert.deepEqual(result[1][0], web3.utils.toBN(value*400/10000));
       assert.equal(1, await clone.getTokenRoyaltiesCount())
+    });
+
+
+    it('test multi-contract artblocks', async function () {
+      // Check override interface
+      assert.equal(await multiContractOverrideArtBlocks.supportsInterface("0x9ca7dc7a"), true);
+      assert.equal(await multiContractOverrideArtBlocks.supportsInterface("0xffffffff"), false);
+
+      // expect revert when asking for royalties of EOA, directly from override contract
+      await truffleAssert.reverts(multiContractOverrideArtBlocks.getRoyalties(another2, 0, {from:another1}), "revert");
+
+      engine = await deployProxy(RoyaltyEngineV1, [registry.address], {initializer: "initialize", from:owner});
+      let value = 1000;
+
+      // expect empty responses when asking for royalties of mockArtBlocks w/o override
+      let result = await engine.getRoyaltyView(mockArtBlocks.address, 0, value, {from:another1});
+      assert.equal(result["recipients"].length, 0);
+      assert.equal(result["amounts"].length, 0);
+
+      // set mockArtBlocks override to be multiContractOverrideArtBlocks
+      await registry.setRoyaltyLookupAddress(mockArtBlocks.address, multiContractOverrideArtBlocks.address, {from:another1});
+
+      // expect override to return mockArtBlocks default royalty results
+      result = await engine.getRoyaltyView(mockArtBlocks.address, 0, value, {from:another1});
+      assert.deepEqual(result[0],["0x0000000000000000000000000000000000000000", another1]);
+      assert.deepEqual(result[1], [web3.utils.toBN(value*4/100), web3.utils.toBN(value*1/100)]);
+
+      // expect override to return mockArtBlocks default royalty results when someone else calls
+      result = await engine.getRoyaltyView(mockArtBlocks.address, 0, value, {from:another2});
+      assert.deepEqual(result[0],["0x0000000000000000000000000000000000000000", another1]);
+      assert.deepEqual(result[1], [web3.utils.toBN(value*4/100), web3.utils.toBN(value*1/100)]);
+
+      // expect to return mockArtBlocks default royalty results (in bps) when calling override contract directly
+      result = await multiContractOverrideArtBlocks.getRoyalties(mockArtBlocks.address, 0, {from:another1});
+      assert.deepEqual(result[0],["0x0000000000000000000000000000000000000000", another1]);
+      assert.deepEqual(result[1], [web3.utils.toBN(10000*4/100), web3.utils.toBN(10000*1/100)]);
+
+      // expect revert when asking for royalties of non-artblocks contract
+      await registry.setRoyaltyLookupAddress(mockContract.address, multiContractOverrideArtBlocks.address, {from:another1});
+      await truffleAssert.reverts(engine.getRoyaltyView(mockContract.address, 0, value, {from:another1}), "revert");
     });
 
   });


### PR DESCRIPTION
## Overview
A multi-contract royalty override interface is proposed to be supported by the RoyaltyEngine. The interface generalizes a request for royalties to `n` recipients, given `tokenAddress` and `tokenId`. Because override contracts are new (not legacy), requiring the new multi-contract overrides to call out support of the new interface per ERC-165 is included. This enables efficient checks in the RoyaltyEngine, avoiding adding another try/catch pattern.

The multi-contract override architecture integrates well with existing Art Blocks contracts. Thus, mock Art Blocks Override contracts are included and added to tests.

Cc @jakerockland 