### PR TITLE
Art Blocks override support

### DIFF
--- a/contracts/mocks/Mock.sol
+++ b/contracts/mocks/Mock.sol
@@ -15,6 +15,7 @@ import "../specs/IEIP2981.sol";
 import "../specs/INiftyGateway.sol";
 import "../specs/IDigitalax.sol";
 import "../specs/IArtBlocks.sol";
+import "../specs/IArtBlocksOverride.sol";
 import "../IRoyaltyEngineV1.sol";
 
 /**
@@ -204,6 +205,35 @@ contract MockDigitalaxAccessControls is IDigitalaxAccessControls {
      constructor() {
          admin = msg.sender;
      }
+ }
+
+ contract MockArtBlocksOverride is IArtBlocksOverride {
+     address payable payee = payable(address(0));
+     address payable secondaryPayee;
+     uint256 totalRoyaltyBps = 500;
+
+     constructor() {
+         secondaryPayee = payable(msg.sender);
+     }
+
+     function setRoyalties(uint256 _totalRoyaltyBps) public {
+         totalRoyaltyBps = _totalRoyaltyBps;
+     }
+
+     function getRoyalties(address /*tokenAddress*/, uint256 /*tokenId*/)
+        external
+        view
+        override
+        returns (address payable[] memory recipients_, uint256[] memory bps) {
+            recipients_ = new address payable[](3);
+            bps = new uint256[](3);
+            // arbitrary 80/20 royalty split for testing
+            recipients_[0] = payee;
+            recipients_[1] = secondaryPayee;
+            bps[0] = totalRoyaltyBps*80/100;
+            bps[1] = totalRoyaltyBps*20/100;
+            // leave last slot as 0 bps
+        }
  }
 
 

--- a/contracts/specs/IArtBlocksOverride.sol
+++ b/contracts/specs/IArtBlocksOverride.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ *  Interface for an Art Blocks override
+ */
+interface IArtBlocksOverride {
+    /**
+     * @dev Get royalites of a token at a given tokenAddress.
+     *      Returns array of receivers and basisPoints.
+     *
+     *  bytes4(keccak256('getRoyalties(address,uint256)')) == 0x9ca7dc7a
+     *
+     *  => 0x9ca7dc7a = 0x9ca7dc7a
+     */
+    function getRoyalties(address tokenAddress, uint256 tokenId)
+        external
+        view
+        returns (address payable[] memory, uint256[] memory);
+}


### PR DESCRIPTION
Simplified PR with minimal changes.

This interface is the same as Zora Override, but with a different function name (`getRoyalties` instead of `convertBitShares`)

Added a few tests added because there were none written for the Zora Override.