### PR TITLE
[fix] Do not include owner shares in ZoraOverride

### DIFF
--- a/contracts/impl/ZoraOverride.sol
+++ b/contracts/impl/ZoraOverride.sol
@@ -38,14 +38,11 @@ contract ZoraOverride is IZoraOverride, ERC165 {
         receivers = new address payable[](totalLength);
         bps = new uint256[](totalLength);
 
-        uint256 currentIndex = 0;
         if (bidShares.creator.value != 0) {
-            receivers[currentIndex] = payable(IZoraMedia(media).tokenCreators(tokenId));
-            bps[currentIndex] = bidShares.creator.value/(10**(18-2));
-            currentIndex++;
+            receivers[0] = payable(IZoraMedia(media).tokenCreators(tokenId));
+            bps[0] = bidShares.creator.value/(10**(18-2));
         }
+        
         return (receivers, bps);
     }
-    
-
 }

--- a/contracts/impl/ZoraOverride.sol
+++ b/contracts/impl/ZoraOverride.sol
@@ -30,7 +30,10 @@ contract ZoraOverride is IZoraOverride, ERC165 {
         // if (bidShares.prevOwner.value != 0) totalLength++;
 
         if (bidShares.creator.value != 0) totalLength++;
-        if (bidShares.owner.value != 0) totalLength++;
+
+        // NOTE: We do not support owner bps because these are expected to be handled by the individual market
+        // implementations and are not truly royalties
+        // if (bidShares.owner.value != 0) totalLength++;
 
         receivers = new address payable[](totalLength);
         bps = new uint256[](totalLength);
@@ -39,11 +42,6 @@ contract ZoraOverride is IZoraOverride, ERC165 {
         if (bidShares.creator.value != 0) {
             receivers[currentIndex] = payable(IZoraMedia(media).tokenCreators(tokenId));
             bps[currentIndex] = bidShares.creator.value/(10**(18-2));
-            currentIndex++;
-        }
-        if (bidShares.owner.value != 0) {
-            receivers[currentIndex] = payable(IZoraMedia(media).ownerOf(tokenId));
-            bps[currentIndex] = bidShares.owner.value/(10**(18-2));
             currentIndex++;
         }
         return (receivers, bps);

--- a/test/registry.js
+++ b/test/registry.js
@@ -18,6 +18,7 @@ const MockDigitalaxAccessControls = artifacts.require("MockDigitalaxAccessContro
 const MockArtBlocks = artifacts.require("MockArtBlocks");
 const MockArtBlocksOverride = artifacts.require("MockArtBlocksOverride");
 const MockERC1155PresetMinterPauser = artifacts.require("MockERC1155PresetMinterPauser");
+const MockZora = artifacts.require("ZoraOverride");
 
 contract('Registry', function ([...accounts]) {
   const [
@@ -53,6 +54,7 @@ contract('Registry', function ([...accounts]) {
     var mockArtBlocks;
     var mockArtBlocksOverride;
     var mockERC1155PresetMinterPauser;
+    var mockZora;
 
     beforeEach(async function () {
       registry = await deployProxy(RoyaltyRegistry, {initializer: "initialize", from:owner});
@@ -72,7 +74,8 @@ contract('Registry', function ([...accounts]) {
       mockDigitalaxNFT = await MockDigitalaxNFT.new(mockDigitalaxAccessControls.address, {from: owner});
       mockArtBlocks = await MockArtBlocks.new({from: artBlocksDeployer});
       mockArtBlocksOverride = await MockArtBlocksOverride.new({from: artBlocksDeployer});
-      mockERC1155PresetMinterPauser = await MockERC1155PresetMinterPauser.new({from: erc1155PresetDeployer});
+      mockERC1155PresetMinterPauser = await MockERC1155PresetMinterPauser.new({ from: erc1155PresetDeployer });
+      mockZora = await MockZora.new();
     });
 
     it('override test', async function () {
@@ -81,7 +84,8 @@ contract('Registry', function ([...accounts]) {
       await truffleAssert.reverts(registry.setRoyaltyLookupAddress(mockContract.address, mockManifold.address, {from: eip2981Deployer}));
       await truffleAssert.reverts(registry.setRoyaltyLookupAddress(mockManifold.address, mockManifold.address, {from: eip2981Deployer}), "Permission denied");
       await registry.setRoyaltyLookupAddress(mockContract.address, mockManifold.address, {from: owner});
-      await registry.setRoyaltyLookupAddress(mockManifold.address, mockFoundation.address, {from: manifoldDeployer});
+      await registry.setRoyaltyLookupAddress(mockManifold.address, mockFoundation.address, { from: manifoldDeployer });
+      await registry.setRoyaltyLookupAddress(mockContract.address, mockZora.address, { from: owner });
     });
 
     it('permissions test', async function() {
@@ -95,7 +99,8 @@ contract('Registry', function ([...accounts]) {
       assert.equal(false, await registry.overrideAllowed(mockNiftyBuilder.address, {from:random}));
       assert.equal(false, await registry.overrideAllowed(mockDigitalaxNFT.address, {from:random}));
       assert.equal(false, await registry.overrideAllowed(mockArtBlocks.address, {from:random}));
-      assert.equal(false, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, {from:random}));
+      assert.equal(false, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, { from: random }));
+      assert.equal(false, await registry.overrideAllowed(mockZora.address, { from: random }));
 
       assert.equal(true, await registry.overrideAllowed(mockManifold.address, {from:manifoldDeployer}));
       assert.equal(true, await registry.overrideAllowed(mockFoundation.address, {from:foundationDeployer}));
@@ -105,7 +110,8 @@ contract('Registry', function ([...accounts]) {
       assert.equal(true, await registry.overrideAllowed(mockNiftyBuilder.address, {from:niftyDeployer}));
       assert.equal(true, await registry.overrideAllowed(mockDigitalaxNFT.address, {from:owner}));
       assert.equal(true, await registry.overrideAllowed(mockArtBlocks.address, {from:artBlocksDeployer}));
-      assert.equal(true, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, {from:erc1155PresetDeployer}));
+      assert.equal(true, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, { from: erc1155PresetDeployer }));
+      assert.equal(true, await registry.overrideAllowed(mockZora.address, { from: owner }))
     })
 
     it('getRoyalty test', async function () {


### PR DESCRIPTION
Unless there is a `prevOwnerBidShare` present on a token, the royalty bps returned by ZoraOverride would always sum to 100%. 

100% royalties causes a revert in the [RoyaltyEngine](https://github.com/manifoldxyz/royalty-registry-solidity/blob/main/contracts/RoyaltyEngineV1.sol#L243).  To fix, we remove the owner calculations from the ZoraOverride since owners are expected to be paid out outside of the royalty calculations (their shares aren't royalties anyways)