### PR TITLE
Add override to check for contract ownership through another contract

### DIFF
--- a/contracts/RoyaltyRegistry.sol
+++ b/contracts/RoyaltyRegistry.sol
@@ -69,6 +69,12 @@ contract RoyaltyRegistry is ERC165, OwnableUpgradeable, IRoyaltyRegistry {
 
         try OwnableUpgradeable(tokenAddress).owner() returns (address owner) {
             if (owner == _msgSender()) return true;
+
+            if (owner.isContract()) {
+              try OwnableUpgradeable(owner).owner() returns (address passThroughOwner) {
+                  if (passThroughOwner == _msgSender()) return true;
+              } catch {}
+            }
         } catch {}
 
         try IAccessControlUpgradeable(tokenAddress).hasRole(0x00, _msgSender()) returns (bool hasRole) {

--- a/test/override.js
+++ b/test/override.js
@@ -18,6 +18,7 @@ contract('Registry', function ([...accounts]) {
     another4,
     another5,
     another6,
+    indirectOwner
   ] = accounts;
 
   describe('Override', function() {
@@ -27,6 +28,8 @@ contract('Registry', function ([...accounts]) {
     var override;
     var overrideCloneable;
     var overrideFactory;
+    var mockDirectOwnerContract;
+    var mockIndirectlyOwnedContract;
 
     beforeEach(async function () {
       registry = await deployProxy(RoyaltyRegistry, {initializer: "initialize", from:owner});
@@ -34,6 +37,10 @@ contract('Registry', function ([...accounts]) {
       override = await EIP2981RoyaltyOverride.new({from: admin});
       overrideCloneable = await EIP2981RoyaltyOverrideCloneable.new();
       overrideFactory = await EIP2981RoyaltyOverrideFactory.new(overrideCloneable.address);
+
+      mockIndirectlyOwnedContract = await MockContract.new({from: indirectOwner});
+      mockDirectOwnerContract = await MockContract.new({from: indirectOwner});
+      await mockIndirectlyOwnedContract.transferOwnership(mockDirectOwnerContract.address, { from: indirectOwner });
     });
 
     it('override test', async function () {
@@ -79,6 +86,17 @@ contract('Registry', function ([...accounts]) {
       assert.equal(result[1].length, 1);
       assert.deepEqual(result[1][0], web3.utils.toBN(value*100/10000));
 
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, 1, value);
+      assert.equal(result[0].length, 0);
+      assert.equal(result[1].length, 0);
+
+      await registry.setRoyaltyLookupAddress(mockIndirectlyOwnedContract.address, override.address, {from: indirectOwner});
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, 1, value);
+      assert.equal(result[0].length, 1);
+      assert.equal(result[0][0], another1);
+      assert.equal(result[1].length, 1);
+      assert.deepEqual(result[1][0], web3.utils.toBN(value*100/10000));
+
       // Creating override clone
       var tx = await overrideFactory.createOverride({from:admin});
       console.log("Create override gas used: %s", tx.receipt.gasUsed);
@@ -117,15 +135,43 @@ contract('Registry', function ([...accounts]) {
       assert.deepEqual(result[1][0], web3.utils.toBN(value*500/10000));
       assert.equal(2, await clone.getTokenRoyaltiesCount());
 
+      await registry.setRoyaltyLookupAddress(mockIndirectlyOwnedContract.address, clone.address, {from: indirectOwner});
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, 3, value);
+      assert.equal(result[0].length, 1);
+      assert.equal(result[0][0], another3);
+      assert.equal(result[1].length, 1);
+      assert.deepEqual(result[1][0], web3.utils.toBN(value*300/10000));
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, 1, value);
+      assert.equal(result[0].length, 1);
+      assert.equal(result[0][0], another4);
+      assert.equal(result[1].length, 1);
+      assert.deepEqual(result[1][0], web3.utils.toBN(value*400/10000));
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, 5, value);
+      assert.equal(result[0].length, 1);
+      assert.equal(result[0][0], another5);
+      assert.equal(result[1].length, 1);
+      assert.deepEqual(result[1][0], web3.utils.toBN(value*500/10000));
+      assert.equal(2, await clone.getTokenRoyaltiesCount());
+
       // Test per token deletion, will go back to default
-      await clone.setTokenRoyalties([[5, '0x0000000000000000000000000000000000000000', 0]], {from:admin})
+      await clone.setTokenRoyalties([[5, '0x0000000000000000000000000000000000000000', 0]], {from:admin});
       result = await engine.getRoyaltyView(mockContract.address, 5, value);
       assert.equal(result[0].length, 1);
       assert.equal(result[0][0], another4);
       assert.equal(result[1].length, 1);
       assert.deepEqual(result[1][0], web3.utils.toBN(value*400/10000));
-      assert.equal(1, await clone.getTokenRoyaltiesCount())
+      assert.equal(1, await clone.getTokenRoyaltiesCount());
+
+      // Test per token deletion, will go back to default
+      await clone.setTokenRoyalties([[5, '0x0000000000000000000000000000000000000000', 0]], {from:admin});
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, 5, value);
+      assert.equal(result[0].length, 1);
+      assert.equal(result[0][0], another4);
+      assert.equal(result[1].length, 1);
+      assert.deepEqual(result[1][0], web3.utils.toBN(value*400/10000));
+      assert.equal(1, await clone.getTokenRoyaltiesCount());
     });
 
   });
 });
+

--- a/test/registry.js
+++ b/test/registry.js
@@ -33,6 +33,7 @@ contract('Registry', function ([...accounts]) {
     niftyDeployer,
     artBlocksDeployer,
     erc1155PresetDeployer,
+    indirectOwner
   ] = accounts;
 
   describe('Registry', function() {
@@ -55,6 +56,8 @@ contract('Registry', function ([...accounts]) {
     var mockArtBlocksOverride;
     var mockERC1155PresetMinterPauser;
     var mockZora;
+    var mockIndirectlyOwnedContract;
+    var mockDirectOwnerContract;
 
     beforeEach(async function () {
       registry = await deployProxy(RoyaltyRegistry, {initializer: "initialize", from:owner});
@@ -76,6 +79,8 @@ contract('Registry', function ([...accounts]) {
       mockArtBlocksOverride = await MockArtBlocksOverride.new({from: artBlocksDeployer});
       mockERC1155PresetMinterPauser = await MockERC1155PresetMinterPauser.new({ from: erc1155PresetDeployer });
       mockZora = await MockZora.new();
+      mockIndirectlyOwnedContract = await MockContract.new({from: defaultDeployer});
+      mockDirectOwnerContract = await MockContract.new({from: defaultDeployer});
     });
 
     it('override test', async function () {
@@ -86,6 +91,10 @@ contract('Registry', function ([...accounts]) {
       await registry.setRoyaltyLookupAddress(mockContract.address, mockManifold.address, {from: owner});
       await registry.setRoyaltyLookupAddress(mockManifold.address, mockFoundation.address, { from: manifoldDeployer });
       await registry.setRoyaltyLookupAddress(mockContract.address, mockZora.address, { from: owner });
+
+      await mockIndirectlyOwnedContract.transferOwnership(mockDirectOwnerContract.address, { from: defaultDeployer });
+      await mockDirectOwnerContract.transferOwnership(indirectOwner, { from: defaultDeployer });
+      await registry.setRoyaltyLookupAddress(mockIndirectlyOwnedContract.address, mockManifold.address, { from: owner });
     });
 
     it('permissions test', async function() {
@@ -101,6 +110,7 @@ contract('Registry', function ([...accounts]) {
       assert.equal(false, await registry.overrideAllowed(mockArtBlocks.address, {from:random}));
       assert.equal(false, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, { from: random }));
       assert.equal(false, await registry.overrideAllowed(mockZora.address, { from: random }));
+      assert.equal(false, await registry.overrideAllowed(mockIndirectlyOwnedContract.address, { from: indirectOwner }));
 
       assert.equal(true, await registry.overrideAllowed(mockManifold.address, {from:manifoldDeployer}));
       assert.equal(true, await registry.overrideAllowed(mockFoundation.address, {from:foundationDeployer}));
@@ -112,7 +122,11 @@ contract('Registry', function ([...accounts]) {
       assert.equal(true, await registry.overrideAllowed(mockArtBlocks.address, {from:artBlocksDeployer}));
       assert.equal(true, await registry.overrideAllowed(mockERC1155PresetMinterPauser.address, { from: erc1155PresetDeployer }));
       assert.equal(true, await registry.overrideAllowed(mockZora.address, { from: owner }))
-    })
+
+      await mockIndirectlyOwnedContract.transferOwnership(mockDirectOwnerContract.address, { from: defaultDeployer });
+      await mockDirectOwnerContract.transferOwnership(indirectOwner, { from: defaultDeployer });
+      assert.equal(true, await registry.overrideAllowed(mockIndirectlyOwnedContract.address, { from: indirectOwner }));
+    });
 
     it('getRoyalty test', async function () {
       engine = await deployProxy(RoyaltyEngineV1, [registry.address], {initializer: "initialize", from:owner});
@@ -124,6 +138,7 @@ contract('Registry', function ([...accounts]) {
       var raribleV2TokenId = 5;
       var eip2981TokenId = 6;
       var artBlocksTokenId = 7;
+      var indirectlyOwnedTokenId = 8;
 
       var unallocatedBps = 100;
       var manifoldBps = 200;
@@ -132,6 +147,7 @@ contract('Registry', function ([...accounts]) {
       var raribleV2Bps = 500;
       var eip2981Bps = 600;
       var randomBps = 100;
+      var indirectlyOwnedTokenBps = 500;
 
       var value = 10000;
       var result;
@@ -172,7 +188,6 @@ contract('Registry', function ([...accounts]) {
       assert.deepEqual(result[1][0], web3.utils.toBN(value*raribleV2Bps/10000));
       assert.equal(result[0][1], random);
       assert.deepEqual(result[1][1], web3.utils.toBN(value*randomBps/10000));
-
 
       await mockManifold.setRoyalties(manifoldTokenId, [manifoldDeployer], [manifoldBps]);
       await mockFoundation.setRoyalties(foundationTokenId, [foundationDeployer], [foundationBps]);
@@ -218,9 +233,20 @@ contract('Registry', function ([...accounts]) {
       assert.equal(result[0].length, 0);
       assert.equal(result[1].length, 0);
 
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, indirectlyOwnedTokenId, value);
+      assert.equal(result[0].length, 0);
+      assert.equal(result[1].length, 0);
+
       // Override royalty logic
       await registry.setRoyaltyLookupAddress(mockContract.address, mockManifold.address, {from: defaultDeployer});
       result = await engine.getRoyaltyView(mockContract.address, unallocatedTokenId, value);
+      assert.equal(result[0].length, 0);
+      assert.equal(result[1].length, 0);
+
+      await mockIndirectlyOwnedContract.transferOwnership(mockDirectOwnerContract.address, { from: defaultDeployer });
+      await mockDirectOwnerContract.transferOwnership(indirectOwner, { from: defaultDeployer });
+      await registry.setRoyaltyLookupAddress(mockIndirectlyOwnedContract.address, mockManifold.address, {from: indirectOwner});
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, indirectlyOwnedTokenId, value);
       assert.equal(result[0].length, 0);
       assert.equal(result[1].length, 0);
 
@@ -229,6 +255,11 @@ contract('Registry', function ([...accounts]) {
       result = await engine.getRoyaltyView(mockContract.address, unallocatedTokenId, value);
       assert.equal(result[0][0], defaultDeployer);
       assert.deepEqual(result[1][0], web3.utils.toBN(value*unallocatedBps/10000));
+
+      await mockManifold.setRoyalties(indirectlyOwnedTokenId, [indirectOwner], [indirectlyOwnedTokenBps]);
+      result = await engine.getRoyaltyView(mockIndirectlyOwnedContract.address, indirectlyOwnedTokenId, value);
+      assert.equal(result[0][0], indirectOwner);
+      assert.deepEqual(result[1][0], web3.utils.toBN(value*indirectlyOwnedTokenBps/10000));
 
       // Simulate paying a royalty and check gas cost
       await mockRoyaltyPayer.deposit({from:owner, value:value*100})
@@ -250,6 +281,14 @@ contract('Registry', function ([...accounts]) {
       tx = await mockRoyaltyPayer.payout(engine.address, mockArtBlocksOverride.address, artBlocksTokenId, value);
       console.log("Payout gas used with art blocks override: %s", tx.receipt.gasUsed);
 
+      var indirectOwnerBalanceBefore = BigInt(await web3.eth.getBalance(indirectOwner));
+      tx = await mockRoyaltyPayer.payout(engine.address, mockIndirectlyOwnedContract.address, indirectlyOwnedTokenId, value);
+      console.log("Payout gas used with indirect override: %s", tx.receipt.gasUsed);
+      var indirectOwnerBalanceAfter = BigInt(await web3.eth.getBalance(indirectOwner));
+      var balanceDiff = indirectOwnerBalanceAfter - indirectOwnerBalanceBefore;
+      balanceDiff = Number(balanceDiff);
+      assert.equal(balanceDiff, value*indirectlyOwnedTokenBps/10000);
+
       // Simulate after running cache
       await engine.getRoyalty(mockManifold.address, manifoldTokenId, value)
       await engine.getRoyalty(mockFoundation.address, foundationTokenId, value)
@@ -257,6 +296,8 @@ contract('Registry', function ([...accounts]) {
       await engine.getRoyalty(mockRaribleV2.address, raribleV2TokenId, value)
       await engine.getRoyalty(mockEIP2981.address, eip2981TokenId, value)
       await engine.getRoyalty(mockArtBlocksOverride.address, artBlocksTokenId, value)
+      await engine.getRoyalty(mockIndirectlyOwnedContract.address, indirectlyOwnedTokenId, value)
+
       await mockRoyaltyPayer.payout(engine.address, mockContract.address, unallocatedTokenId, value);
       tx = await mockRoyaltyPayer.payout(engine.address, mockContract.address, 1, value);
       console.log("CACHE: Payout gas no royalties: %s", tx.receipt.gasUsed);
@@ -274,6 +315,16 @@ contract('Registry', function ([...accounts]) {
       console.log("CACHE: Payout gas used with override: %s", tx.receipt.gasUsed);
       tx = await mockRoyaltyPayer.payout(engine.address, mockArtBlocksOverride.address, artBlocksTokenId, value);
       console.log("CACHE: Payout gas used with art blocks override: %s", tx.receipt.gasUsed);
+      tx = await mockRoyaltyPayer.payout(engine.address, mockIndirectlyOwnedContract.address, indirectlyOwnedTokenId, value);
+      console.log("CACHE: Payout gas used with override: %s", tx.receipt.gasUsed);
+
+      indirectOwnerBalanceBefore = BigInt(await web3.eth.getBalance(indirectOwner));
+      tx = await mockRoyaltyPayer.payout(engine.address, mockIndirectlyOwnedContract.address, indirectlyOwnedTokenId, value);
+      console.log("Payout gas used with indirect override: %s", tx.receipt.gasUsed);
+      indirectOwnerBalanceAfter = BigInt(await web3.eth.getBalance(indirectOwner));
+      balanceDiff = indirectOwnerBalanceAfter - indirectOwnerBalanceBefore;
+      balanceDiff = Number(balanceDiff);
+      assert.equal(balanceDiff, value*indirectlyOwnedTokenBps/10000);
 
       // Foundation override test
       await truffleAssert.reverts(registry.setRoyaltyLookupAddress(mockFoundation.address, mockManifold.address, {from: random}));
@@ -299,7 +350,6 @@ contract('Registry', function ([...accounts]) {
       assert.equal(await engine.getCachedRoyaltySpec(mockEIP2981.address), 5);
       await engine.invalidateCachedRoyaltySpec(mockEIP2981.address, {from:random});
       assert.equal(await engine.getCachedRoyaltySpec(mockEIP2981.address), 0);
-      
     });
 
     it('invalid royalties test', async function () {
@@ -312,7 +362,6 @@ contract('Registry', function ([...accounts]) {
       var raribleV2TokenId = 5;
       var eip2981TokenId = 6;
       var artBlocksTokenId = 7;
-
 
       await mockManifold.setRoyalties(manifoldTokenId, [manifoldDeployer], [10000]);
       await mockFoundation.setRoyalties(foundationTokenId, [foundationDeployer], [10000]);
@@ -354,6 +403,7 @@ contract('Registry', function ([...accounts]) {
       await mockRoyaltyPayer.payout(engine.address, mockRaribleV2.address, raribleV2TokenId, value);
       await mockRoyaltyPayer.payout(engine.address, mockEIP2981.address, eip2981TokenId, value);
       await mockRoyaltyPayer.payout(engine.address, mockArtBlocksOverride.address, artBlocksTokenId, value);
+      await mockRoyaltyPayer.payout(engine.address, mockIndirectlyOwnedContract.address, 1, value);
 
       // Simulate after running cache
       await engine.getRoyalty(mockManifold.address, manifoldTokenId, value)
@@ -377,8 +427,9 @@ contract('Registry', function ([...accounts]) {
       await truffleAssert.reverts(engine.getRoyaltyView(mockRaribleV2.address, raribleV2TokenId, value), "Invalid royalty amount");
       await truffleAssert.reverts(engine.getRoyaltyView(mockEIP2981.address, eip2981TokenId, value), "Invalid royalty amount");
       await truffleAssert.reverts(engine.getRoyaltyView(mockArtBlocksOverride.address, artBlocksTokenId, value), "Invalid royalty amount");
-
     });
 
   });
 });
+
+


### PR DESCRIPTION
This change introduces a new override that checks for msg.sender ownership of token address A _through_ msg.sender ownership of token address B. If the owner of the tokenAddress is not the msg.sender, and if the owner of the tokenAddress is a contract, then allow the override if the msg.sender is the owner of the contract that owns the tokenAddress.

Please see [this issue](https://github.com/manifoldxyz/royalty-registry-solidity/issues/24) for more background.

A couple questions for discussion:
* `isContract()` is already used in RoyaltyRegistry.sol, but is it [safe](https://stackoverflow.com/questions/37644395/how-to-find-out-if-an-ethereum-address-is-a-contract#:~:text=There%20is%20no%20way%20in,with%20humans%20and%20other%20contracts.)?
* I've included .js tests for the change and have tested on a local personal blockchain (truffle/ganache). The [contributions](https://github.com/manifoldxyz/royalty-registry-solidity#contributions) section of the readme doesn't mention it, but I'd imagine some testing on Rinkeby along with the [royalty registry client](https://github.com/manifoldxyz/royalty-registry-client) is desirable as well. If the approach I'm proposing in this PR is accepted, I'm happy to follow up with additional testing but could use a few pointers when it comes to the royalty registry client