### PR TITLE
Add fallback look up

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ As new standards are adopted, they can be added to the royalty engine.  If new s
 
 The royalty engine also contains a spec cache to make lookups faster.  The cache is filled only if getRoyaltyAndCacheSpec is called, which is only useable within another contract as it is a mutable function.
 
+#### v2
+
+The royalty engine has been update to a new version (v2), this version introduces a fallback lookup for collections without on chain royalty configuration. The primary source for the fallback data is the OpenSea off chain royalty dataset.
+
 #### Methods
 
 ---

--- a/contracts/IFallbackable.sol
+++ b/contracts/IFallbackable.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IFallbackable {
+    /**
+     * @notice Set the address for fallback royalty look up
+     * @dev This should be a permissioned function
+     * @param fallbackRoyaltyLookup Address of the fallback look up contract
+     */
+    function setFallbackRoyaltyLookup(address fallbackRoyaltyLookup) external;
+}

--- a/contracts/RoyaltyEngineV2.sol
+++ b/contracts/RoyaltyEngineV2.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+
+import "./libraries/SuperRareContracts.sol";
+
+import "./specs/IManifold.sol";
+import "./specs/IRarible.sol";
+import "./specs/IFoundation.sol";
+import "./specs/ISuperRare.sol";
+import "./specs/IEIP2981.sol";
+import "./specs/IZoraOverride.sol";
+import "./specs/IArtBlocksOverride.sol";
+import "./specs/IKODAV2Override.sol";
+import "./IRoyaltyEngineV1.sol";
+import "./IRoyaltyRegistry.sol";
+
+/**
+ * @dev Engine to lookup royalty configurations
+ */
+contract RoyaltyEngineV2 is ERC165, OwnableUpgradeable, IRoyaltyEngineV1 {
+    using AddressUpgradeable for address;
+
+    // Use int16 for specs to support future spec additions
+    // When we add a spec, we also decrement the NONE value
+    // Anything > NONE and <= NOT_CONFIGURED is considered not configured
+    int16 constant private NONE = -1;
+    int16 constant private NOT_CONFIGURED = 0;
+    int16 constant private MANIFOLD = 1;
+    int16 constant private RARIBLEV1 = 2;
+    int16 constant private RARIBLEV2 = 3;
+    int16 constant private FOUNDATION = 4;
+    int16 constant private EIP2981 = 5;
+    int16 constant private SUPERRARE = 6;
+    int16 constant private ZORA = 7;
+    int16 constant private ARTBLOCKS = 8;
+    int16 constant private KNOWNORIGINV2 = 9;
+
+    mapping (address => int16) _specCache;
+
+    address public royaltyRegistry;
+
+    function initialize(address royaltyRegistry_) public initializer {
+        __Ownable_init_unchained();
+        require(ERC165Checker.supportsInterface(royaltyRegistry_, type(IRoyaltyRegistry).interfaceId));
+        royaltyRegistry = royaltyRegistry_;
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+        return interfaceId == type(IRoyaltyEngineV1).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Invalidate the cached spec (useful for situations where tooken royalty implementation changes to a different spec)
+     */
+    function invalidateCachedRoyaltySpec(address tokenAddress) public {
+        address royaltyAddress = IRoyaltyRegistry(royaltyRegistry).getRoyaltyLookupAddress(tokenAddress);
+        delete _specCache[royaltyAddress];
+    }
+
+    /**
+     * @dev View function to get the cached spec of a token
+     */
+    function getCachedRoyaltySpec(address tokenAddress) public view returns(int16) {
+        address royaltyAddress = IRoyaltyRegistry(royaltyRegistry).getRoyaltyLookupAddress(tokenAddress);
+        return _specCache[royaltyAddress];
+    }
+
+    /**
+     * @dev See {IRoyaltyEngineV1-getRoyalty}
+     */
+    function getRoyalty(address tokenAddress, uint256 tokenId, uint256 value) public override returns(address payable[] memory recipients, uint256[] memory amounts) {
+        // External call to limit gas
+        try this._getRoyaltyAndSpec{gas: 100000}(tokenAddress, tokenId, value) returns (address payable[] memory _recipients, uint256[] memory _amounts, int16 spec, address royaltyAddress, bool addToCache) {
+            if (addToCache) _specCache[royaltyAddress] = spec;
+            return (_recipients, _amounts);
+        } catch {
+            revert ("Invalid royalty amount");
+        }
+    }
+
+    /**
+     * @dev See {IRoyaltyEngineV1-getRoyaltyView}.
+     */
+    function getRoyaltyView(address tokenAddress, uint256 tokenId, uint256 value) public view override returns(address payable[] memory recipients, uint256[] memory amounts) {
+        // External call to limit gas
+        try this._getRoyaltyAndSpec{gas: 100000}(tokenAddress, tokenId, value) returns (address payable[] memory _recipients, uint256[] memory _amounts, int16, address, bool) {
+            return (_recipients, _amounts);
+        } catch {
+            revert ("Invalid royalty amount");
+        }
+    }
+
+    /**
+     * @dev Get the royalty and royalty spec for a given token
+     *
+     * returns recipients array, amounts array, royalty spec, royalty address, whether or not to add to cache
+     */
+    function _getRoyaltyAndSpec(address tokenAddress, uint256 tokenId, uint256 value) external view returns(address payable[] memory recipients, uint256[] memory amounts, int16 spec, address royaltyAddress, bool addToCache) {
+        require(msg.sender == address(this), "Only Engine");
+
+        royaltyAddress = IRoyaltyRegistry(royaltyRegistry).getRoyaltyLookupAddress(tokenAddress);
+        spec = _specCache[royaltyAddress];
+
+        if (spec <= NOT_CONFIGURED && spec > NONE) {
+            // No spec configured yet, so we need to detect the spec
+            addToCache = true;
+
+            // SuperRare handling
+            if (tokenAddress == SuperRareContracts.SUPERRARE_V1 || tokenAddress == SuperRareContracts.SUPERRARE_V2) {
+                try ISuperRareRegistry(SuperRareContracts.SUPERRARE_REGISTRY).tokenCreator(tokenAddress, tokenId) returns(address payable creator) {
+                    try ISuperRareRegistry(SuperRareContracts.SUPERRARE_REGISTRY).calculateRoyaltyFee(tokenAddress, tokenId, value) returns(uint256 amount) {
+                        recipients = new address payable[](1);
+                        amounts = new uint256[](1);
+                        recipients[0] = creator;
+                        amounts[0] = amount;
+                        return (recipients, amounts, SUPERRARE, royaltyAddress, addToCache);
+                    } catch {}
+                } catch {}
+            }
+            try IEIP2981(royaltyAddress).royaltyInfo(tokenId, value) returns(address recipient, uint256 amount) {
+                // Supports EIP2981.  Return amounts
+                require(amount < value, "Invalid royalty amount");
+                recipients = new address payable[](1);
+                amounts = new uint256[](1);
+                recipients[0] = payable(recipient);
+                amounts[0] = amount;
+                return (recipients, amounts, EIP2981, royaltyAddress, addToCache);
+            } catch {}
+            try IManifold(royaltyAddress).getRoyalties(tokenId) returns(address payable[] memory recipients_, uint256[] memory bps) {
+                // Supports manifold interface.  Compute amounts
+                require(recipients_.length == bps.length);
+                return (recipients_, _computeAmounts(value, bps), MANIFOLD, royaltyAddress, addToCache);
+            } catch {}
+            try IRaribleV2(royaltyAddress).getRaribleV2Royalties(tokenId) returns(IRaribleV2.Part[] memory royalties) {
+                // Supports rarible v2 interface. Compute amounts
+                recipients = new address payable[](royalties.length);
+                amounts = new uint256[](royalties.length);
+                uint256 totalAmount;
+                for (uint i = 0; i < royalties.length; i++) {
+                    recipients[i] = royalties[i].account;
+                    amounts[i] = value*royalties[i].value/10000;
+                    totalAmount += amounts[i];
+                }
+                require(totalAmount < value, "Invalid royalty amount");
+                return (recipients, amounts, RARIBLEV2, royaltyAddress, addToCache);
+            } catch {}
+            try IRaribleV1(royaltyAddress).getFeeRecipients(tokenId) returns(address payable[] memory recipients_) {
+                // Supports rarible v1 interface. Compute amounts
+                recipients_ = IRaribleV1(royaltyAddress).getFeeRecipients(tokenId);
+                try IRaribleV1(royaltyAddress).getFeeBps(tokenId) returns (uint256[] memory bps) {
+                    require(recipients_.length == bps.length);
+                    return (recipients_, _computeAmounts(value, bps), RARIBLEV1, royaltyAddress, addToCache);
+                } catch {}
+            } catch {}
+            try IFoundation(royaltyAddress).getFees(tokenId) returns(address payable[] memory recipients_, uint256[] memory bps) {
+                // Supports foundation interface.  Compute amounts
+                require(recipients_.length == bps.length);
+                return (recipients_, _computeAmounts(value, bps), FOUNDATION, royaltyAddress, addToCache);
+            } catch {}
+            try IZoraOverride(royaltyAddress).convertBidShares(tokenAddress, tokenId) returns(address payable[] memory recipients_, uint256[] memory bps) {
+                // Support Zora override
+                require(recipients_.length == bps.length);
+                return (recipients_, _computeAmounts(value, bps), ZORA, royaltyAddress, addToCache);
+            } catch {}
+            try IArtBlocksOverride(royaltyAddress).getRoyalties(tokenAddress, tokenId) returns(address payable[] memory recipients_, uint256[] memory bps) {
+                // Support Art Blocks override
+                require(recipients_.length == bps.length);
+                return (recipients_, _computeAmounts(value, bps), ARTBLOCKS, royaltyAddress, addToCache);
+            } catch {}
+            try IKODAV2Override(royaltyAddress).getKODAV2RoyaltyInfo(tokenAddress, tokenId, value) returns(address payable[] memory _recipients, uint256[] memory _amounts) {
+                // Support KODA V2 override
+                require(_recipients.length == _amounts.length);
+                return (_recipients, _amounts, KNOWNORIGINV2, royaltyAddress, addToCache);
+            } catch {}
+
+            // No supported royalties configured
+            return (recipients, amounts, NONE, royaltyAddress, addToCache);
+        } else {
+            // Spec exists, just execute the appropriate one
+            addToCache = false;
+            if (spec == NONE) {
+                return (recipients, amounts, spec, royaltyAddress, addToCache);
+            } else if (spec == MANIFOLD) {
+                // Manifold spec
+                uint256[] memory bps;
+                (recipients, bps) = IManifold(royaltyAddress).getRoyalties(tokenId);
+                require(recipients.length == bps.length);
+                return (recipients, _computeAmounts(value, bps), spec, royaltyAddress, addToCache);
+            } else if (spec == RARIBLEV2) {
+                // Rarible v2 spec
+                IRaribleV2.Part[] memory royalties;
+                royalties = IRaribleV2(royaltyAddress).getRaribleV2Royalties(tokenId);
+                recipients = new address payable[](royalties.length);
+                amounts = new uint256[](royalties.length);
+                uint256 totalAmount;
+                for (uint i = 0; i < royalties.length; i++) {
+                    recipients[i] = royalties[i].account;
+                    amounts[i] = value*royalties[i].value/10000;
+                    totalAmount += amounts[i];
+                }
+                require(totalAmount < value, "Invalid royalty amount");
+                return (recipients, amounts, spec, royaltyAddress, addToCache);
+            } else if (spec == RARIBLEV1) {
+                // Rarible v1 spec
+                uint256[] memory bps;
+                recipients = IRaribleV1(royaltyAddress).getFeeRecipients(tokenId);
+                bps = IRaribleV1(royaltyAddress).getFeeBps(tokenId);
+                require(recipients.length == bps.length);
+                return (recipients, _computeAmounts(value, bps), spec, royaltyAddress, addToCache);
+            } else if (spec == FOUNDATION) {
+                // Foundation spec
+                uint256[] memory bps;
+                (recipients, bps) = IFoundation(royaltyAddress).getFees(tokenId);
+                require(recipients.length == bps.length);
+                return (recipients, _computeAmounts(value, bps), spec, royaltyAddress, addToCache);
+            } else if (spec == EIP2981) {
+                // EIP2981 spec
+                (address recipient, uint256 amount) = IEIP2981(royaltyAddress).royaltyInfo(tokenId, value);
+                require(amount < value, "Invalid royalty amount");
+                recipients = new address payable[](1);
+                amounts = new uint256[](1);
+                recipients[0] = payable(recipient);
+                amounts[0] = amount;
+                return (recipients, amounts, spec, royaltyAddress, addToCache);
+            } else if (spec == SUPERRARE) {
+                // SUPERRARE spec
+                address payable creator = ISuperRareRegistry(SuperRareContracts.SUPERRARE_REGISTRY).tokenCreator(tokenAddress, tokenId);
+                uint256 amount = ISuperRareRegistry(SuperRareContracts.SUPERRARE_REGISTRY).calculateRoyaltyFee(tokenAddress, tokenId, value);
+                recipients = new address payable[](1);
+                amounts = new uint256[](1);
+                recipients[0] = creator;
+                amounts[0] = amount;
+                return (recipients, amounts, spec, royaltyAddress, addToCache);
+            } else if (spec == ZORA) {
+                // Zora spec
+                uint256[] memory bps;
+                (recipients, bps) = IZoraOverride(royaltyAddress).convertBidShares(tokenAddress, tokenId);
+                require(recipients.length == bps.length);
+                return (recipients, _computeAmounts(value, bps), spec, royaltyAddress, addToCache);
+            } else if (spec == ARTBLOCKS) {
+                // Art Blocks spec
+                uint256[] memory bps;
+                (recipients, bps) = IArtBlocksOverride(royaltyAddress).getRoyalties(tokenAddress, tokenId);
+                require(recipients.length == bps.length);
+                return (recipients, _computeAmounts(value, bps), spec, royaltyAddress, addToCache);
+            } else if (spec == KNOWNORIGINV2) {
+                // KnownOrigin.io V2 spec (V3 falls under EIP2981)
+                (recipients, amounts) = IKODAV2Override(royaltyAddress).getKODAV2RoyaltyInfo(tokenAddress, tokenId, value);
+                return (recipients, amounts, spec, royaltyAddress, addToCache);
+            }
+        }
+    }
+
+    /**
+     * Compute royalty amounts
+     */
+    function _computeAmounts(uint256 value, uint256[] memory bps) private pure returns(uint256[] memory amounts) {
+        amounts = new uint256[](bps.length);
+        uint256 totalAmount;
+        for (uint i = 0; i < bps.length; i++) {
+            amounts[i] = value*bps[i]/10000;
+            totalAmount += amounts[i];
+        }
+        require(totalAmount < value, "Invalid royalty amount");
+        return amounts;
+    }
+
+
+}

--- a/contracts/mocks/Mock.sol
+++ b/contracts/mocks/Mock.sol
@@ -17,6 +17,7 @@ import "../specs/IDigitalax.sol";
 import "../specs/IArtBlocks.sol";
 import "../specs/IArtBlocksOverride.sol";
 import "../specs/IKODAV2Override.sol";
+import "../specs/IRoyaltyLookUp.sol";
 import "../IRoyaltyEngineV1.sol";
 
 /**
@@ -234,6 +235,31 @@ contract MockDigitalaxAccessControls is IDigitalaxAccessControls {
             bps[0] = totalRoyaltyBps*80/100;
             bps[1] = totalRoyaltyBps*20/100;
             // leave last slot as 0 bps
+        }
+ }
+
+ contract MockRoyaltyLookUp is IRoyaltyLookUp {
+     address _expectedCollection;
+     uint256 _expectedTokenId;
+     address payable[] private _recipients;
+     uint256[] private _bps;
+
+
+     function setTest(address expectedCollection, uint expectedTokenId, address payable[] calldata recipients, uint256[] calldata bps) external {
+         _expectedCollection = expectedCollection;
+         _expectedTokenId = expectedTokenId;
+         _recipients = recipients;
+         _bps = bps;
+     }
+
+     function getRoyalties(address tokenAddress, uint256 tokenId)
+        external
+        view
+        override
+        returns (address payable[] memory, uint256[] memory) {
+            require(tokenAddress == _expectedCollection, "Test:Wrong token address queried");
+            require(tokenId == _expectedTokenId, "Test:Wrong token id queried");
+            return (_recipients, _bps);
         }
  }
 

--- a/contracts/specs/IRoyaltyLookUp.sol
+++ b/contracts/specs/IRoyaltyLookUp.sol
@@ -14,10 +14,10 @@ interface IRoyaltyLookUp {
      * @param tokenAddress Token for which to retrieve the royalty
      * @param tokenId Individual Token Id for which to retrieve the royalty. This is optional.
      * @return recipients List of recipients for the royalty. If empty, no royalty is set.
-     * @return feeInBPS List of fees express in bps to send to the recipients at the same index
+     * @return feesInBPS List of fees express in bps to send to the recipients at the same index
      */
     function getRoyalties(address tokenAddress, uint256 tokenId)
         external
         view
-        returns (address payable[] memory recipients, uint256[] memory feeInBPS);
+        returns (address payable[] memory recipients, uint256[] memory feesInBPS);
 }

--- a/contracts/specs/IRoyaltyLookUp.sol
+++ b/contracts/specs/IRoyaltyLookUp.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title Royalty lookup
+ * @notice This interface represent a type of contracts which allow royalty look up for a collection and a token id.
+ */
+interface IRoyaltyLookUp {
+    /**
+     * @notice This function retrieves the set of recipients and respective fees for a collection 
+               and optionally a specific token therein
+     * @dev Token Id can be ignored if royalty is set at the token collection level
+     * @param tokenAddress Token for which to retrieve the royalty
+     * @param tokenId Individual Token Id for which to retrieve the royalty. This is optional.
+     * @return recipients List of recipients for the royalty. If empty, no royalty is set.
+     * @return feeInBPS List of fees express in bps to send to the recipients at the same index
+     */
+    function getRoyalties(address tokenAddress, uint256 tokenId)
+        external
+        view
+        returns (address payable[] memory recipients, uint256[] memory feeInBPS);
+}

--- a/test/fallback.js
+++ b/test/fallback.js
@@ -1,0 +1,128 @@
+const truffleAssert = require("truffle-assertions");
+const { deployProxy } = require("@openzeppelin/truffle-upgrades");
+
+const RoyaltyRegistry = artifacts.require("RoyaltyRegistry");
+const RoyaltyEngineV2 = artifacts.require("RoyaltyEngineV2");
+const MockContract = artifacts.require("MockContract");
+const MockManifold = artifacts.require("MockManifold");
+const MockRoyaltyLookUp = artifacts.require("MockRoyaltyLookUp");
+const MockEIP2981 = artifacts.require("MockEIP2981");
+
+contract("Registry", function ([...accounts]) {
+  const [owner, random, defaultDeployer, manifoldDeployer, eip2981Deployer] =
+    accounts;
+
+  describe("Registry", function () {
+    var registry;
+    var engine;
+    var mockContract;
+    var randomContract;
+    var mockManifold;
+    var mockLockup;
+    var mockEIP2981;
+
+    beforeEach(async function () {
+      registry = await deployProxy(RoyaltyRegistry, {
+        initializer: "initialize",
+        from: owner,
+      });
+      mockContract = await MockContract.new({ from: defaultDeployer });
+      randomContract = await MockContract.new({ from: defaultDeployer });
+      mockManifold = await MockManifold.new({ from: manifoldDeployer });
+      mockLockup = await MockRoyaltyLookUp.new({ from: manifoldDeployer });
+      mockEIP2981 = await MockEIP2981.new({ from: eip2981Deployer });
+    });
+
+    it("reverts if non owner sets fallback address", async function () {
+      engine = await deployProxy(RoyaltyEngineV2, [registry.address], {
+        initializer: "initialize",
+        from: owner,
+      });
+      await truffleAssert.reverts(
+        engine.setFallbackRoyaltyLookup(mockLockup.address, {
+          from: eip2981Deployer,
+        }),
+        "Ownable: caller is not the owner"
+      );
+    });
+
+    it("fallbacks if lookup address not found", async function () {
+      engine = await deployProxy(RoyaltyEngineV2, [registry.address], {
+        initializer: "initialize",
+        from: owner,
+      });
+
+      var fallbackedTokenId = 0;
+      var fallbackBps1 = 100;
+      var fallbackBps2 = 200;
+      var eip2981Bps = 300;
+      var value = 10000;
+      var result;
+
+      // 1) No royalty if no override and no fallback
+      result = await engine.getRoyaltyView(
+        randomContract.address,
+        fallbackedTokenId,
+        1000
+      );
+
+      assert.equal(result[0].length, 0);
+      assert.equal(result[1].length, 0);
+
+      // 2) Get royalty from fallback registry
+      await mockLockup.setTest(
+        randomContract.address,
+        fallbackedTokenId,
+        [manifoldDeployer, random],
+        [fallbackBps1, fallbackBps2]
+      );
+
+      await engine.setFallbackRoyaltyLookup(mockLockup.address);
+
+      result = await engine.getRoyaltyView(
+        randomContract.address,
+        fallbackedTokenId,
+        value
+      );
+      assert.equal(result[0].length, 2);
+      assert.equal(result[1].length, 2);
+      assert.equal(result[0][0], manifoldDeployer);
+      assert.deepEqual(
+        result[1][0],
+        web3.utils.toBN((value * fallbackBps1) / 10000)
+      );
+      assert.equal(result[0][1], random);
+      assert.deepEqual(
+        result[1][1],
+        web3.utils.toBN((value * fallbackBps2) / 10000)
+      );
+
+      await mockEIP2981.setRoyalties(
+        fallbackedTokenId,
+        [eip2981Deployer],
+        [eip2981Bps]
+      );
+
+      // 3) Get royalty from override
+      await registry.setRoyaltyLookupAddress(
+        randomContract.address,
+        mockEIP2981.address,
+        { from: defaultDeployer }
+      );
+
+      result = await engine.getRoyaltyView(
+        randomContract.address,
+        fallbackedTokenId,
+        value
+      );
+
+      assert.equal(result[0].length, 1);
+      assert.equal(result[1].length, 1);
+      assert.equal(result[0][0], eip2981Deployer);
+      assert.deepEqual(
+        result[1][0],
+        web3.utils.toBN((value * eip2981Bps) / 10000)
+      );
+    });
+  });
+});

--- a/test/override.js
+++ b/test/override.js
@@ -5,7 +5,7 @@ const EIP2981RoyaltyOverride = artifacts.require("EIP2981RoyaltyOverride");
 const EIP2981RoyaltyOverrideCloneable = artifacts.require("EIP2981RoyaltyOverrideCloneable");
 const EIP2981RoyaltyOverrideFactory = artifacts.require("EIP2981RoyaltyOverrideFactory");
 const RoyaltyRegistry = artifacts.require("RoyaltyRegistry");
-const RoyaltyEngineV1 = artifacts.require("RoyaltyEngineV1")
+const RoyaltyEngineV2 = artifacts.require("RoyaltyEngineV2")
 const MockContract = artifacts.require("MockContract");
 
 contract('Registry', function ([...accounts]) {
@@ -55,7 +55,7 @@ contract('Registry', function ([...accounts]) {
       await truffleAssert.reverts(override.setTokenRoyalties([[1, another1, 10000]], {from:admin}), "Invalid bps");
       await truffleAssert.reverts(override.setDefaultRoyalty([another1, 10000], {from:admin}), "Invalid bps");
 
-      engine = await deployProxy(RoyaltyEngineV1, [registry.address], {initializer: "initialize", from:owner});
+      engine = await deployProxy(RoyaltyEngineV2, [registry.address], {initializer: "initialize", from:owner});
       let value = 1000;
 
       let result = await override.royaltyInfo(1, value);

--- a/test/registry.js
+++ b/test/registry.js
@@ -2,7 +2,7 @@ const truffleAssert = require('truffle-assertions');
 const { deployProxy } = require('@openzeppelin/truffle-upgrades');
 
 const RoyaltyRegistry = artifacts.require("RoyaltyRegistry");
-const RoyaltyEngineV1 = artifacts.require("RoyaltyEngineV1")
+const RoyaltyEngineV2 = artifacts.require("RoyaltyEngineV2")
 const MockContract = artifacts.require("MockContract");
 const MockManifold = artifacts.require("MockManifold");
 const MockFoundation = artifacts.require("MockFoundation");
@@ -137,7 +137,7 @@ contract('Registry', function ([...accounts]) {
     });
 
     it('getRoyalty test', async function () {
-      engine = await deployProxy(RoyaltyEngineV1, [registry.address], {initializer: "initialize", from:owner});
+      engine = await deployProxy(RoyaltyEngineV2, [registry.address], {initializer: "initialize", from:owner});
 
       var unallocatedTokenId = 1;
       var manifoldTokenId = 2;
@@ -378,7 +378,7 @@ contract('Registry', function ([...accounts]) {
     });
 
     it('invalid royalties test', async function () {
-      engine = await deployProxy(RoyaltyEngineV1, [registry.address], {initializer: "initialize", from:owner});
+      engine = await deployProxy(RoyaltyEngineV2, [registry.address], {initializer: "initialize", from:owner});
 
       var unallocatedTokenId = 1;
       var manifoldTokenId = 2;


### PR DESCRIPTION
## Rationale

Adoption of on-chain royalties is very low. something like 26% of the top 1000 collections vs 74% on opensea. 
This PR adds a fallback look up which will be populated with OpenSea off chain royalty data.

## High level overview

this PR adds in the royalty engine the following:

- Fallback lookup address field
- A new FALLBACK spec

The fallback spec would be used and cached when everything else fails. After the caching the fallback address is implicitly associated as look up for the collection address until an override is provided.

## Design considerations

The single function in the fallback interface:

```solidity
    function getRoyalties(address tokenAddress, uint256 tokenId)
        external
        view
        returns (address payable[] memory recipients, uint256[] memory feesInBPS);
```

could be made more efficient by passing the transaction amount and returning the calculated fees, the author decided against this solution to keep the contract as a pure look up as opposed to a calculator.

## Fallback Lookup Implementation

A tentative implementation can be found [here](https://github.com/reservoirprotocol/fallback-royalty-engine/blob/58e49d3d74f2bd2e6fe1639d8dd73c97ea6f0248/src/FallbackRoyaltyLookUp.sol#L108)