### PR TITLE
Add overloaded external overrideAllowed method

### DIFF
--- a/contracts/IRoyaltyRegistry.sol
+++ b/contracts/IRoyaltyRegistry.sol
@@ -34,4 +34,11 @@ interface IRoyaltyRegistry is IERC165 {
      * @param tokenAddress    - The token address you are looking up the royalty for
      */
     function overrideAllowed(address tokenAddress) external view returns (bool);
+
+    /**
+     * Whether or not an arbitrary caller can override the royalty address for the given token address
+     *
+     * @param tokenAddress    - The token address you are looking up the royalty for
+     */
+    function overrideAllowed(address tokenAddress, address caller) external view returns (bool);
 }

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -34,6 +34,15 @@ contract RegistryTest is BaseOverrideTest {
         _testOverrideAllowed(makeAddr("owner"), tokenAddress);
     }
 
+    function testOverrideAllowed_Overloaded() public {
+        address tokenAddress = address(ownable);
+        ownable.transferOwnership(makeAddr("owner"));
+        vm.prank(registry.owner());
+        assertTrue(registry.overrideAllowed(tokenAddress, registry.owner()));
+        assertTrue(registry.overrideAllowed(tokenAddress, makeAddr("owner")));
+        assertFalse(registry.overrideAllowed(tokenAddress, makeAddr("not authed")));
+    }
+
     function _testOverrideAllowed(address authedCaller, address tokenAddress) internal {
         vm.prank(registry.owner());
         assertTrue(registry.overrideAllowed(tokenAddress));


### PR DESCRIPTION
The original `overrideAllowed` is strange in that it's a view method that always uses the caller – making it impractical for debugging registry override issues without scripting tools. This adds a second method with the signature

```solidity
function overrideAllowed(address tokenAddress, address caller) external view returns (bool);
```

to mitigate.